### PR TITLE
fixes NullReferenceException deserializing null sub-objects from json

### DIFF
--- a/src/Uno.CodeGen.Tests/Given_ImmutableEntity.Newtownsoft.cs
+++ b/src/Uno.CodeGen.Tests/Given_ImmutableEntity.Newtownsoft.cs
@@ -63,5 +63,27 @@ namespace Uno.CodeGen.Tests
 			a.Entity­.MyField1.Should().Be(1);
 			a.Entity­.MyField2.Should().Be(2);
 		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_ABuilder_WithNull_Using_JsonNet()
+		{
+			const string json = "{IsSomething:false, T:null, Entity:null}";
+			var a = JsonConvert.DeserializeObject<A.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_A_WithNull_Using_JsonNet()
+		{
+			const string json = "{IsSomething:false, T:null, Entity:null}";
+			var a = JsonConvert.DeserializeObject<A>(json);
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().BeNull();
+		}
 	}
 }

--- a/src/Uno.CodeGen/ImmutableGenerator.cs
+++ b/src/Uno.CodeGen/ImmutableGenerator.cs
@@ -794,7 +794,7 @@ $@"public sealed class {symbolName}BuilderJsonConverterTo{symbolName}{genericArg
 	public override object ReadJson(global::Newtonsoft.Json.JsonReader reader, Type objectType, object existingValue, global::Newtonsoft.Json.JsonSerializer serializer)
 	{{
 		var o = serializer.Deserialize<{symbolNameWithGenerics}.Builder>(reader);
-		return ({symbolNameWithGenerics})o;
+		return o?.ToImmutable();
 	}}
 
 	public override bool CanConvert(Type objectType)


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
Deserializing from json an immutable object containing a reference to another immutable object throws a NullReferenceException if the sub-object is null in json.
To reproduce the issue merge only src/Uno.CodeGen.Tests/Given_ImmutableEntity.Newtownsoft.cs  leaving current src/Uno.CodeGen/ImmutableGenerator.cs

## What is the new behavior?
The object is correctly deserialized with sub-object reference set to null


## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.CodeGen/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.CodeGen/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->