### PR TITLE
GetMandatoryTypeSymbol were apply on optional types

### DIFF
--- a/src/Uno.CodeGen.Tests.MinimalDeps/Class1.cs
+++ b/src/Uno.CodeGen.Tests.MinimalDeps/Class1.cs
@@ -1,0 +1,25 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+namespace Uno.CodeGen.Tests.MinimalDeps
+{
+	[GeneratedImmutable]
+	public partial class Class1
+	{
+		[EqualityHash]
+		public string Id { get; }
+	}
+}

--- a/src/Uno.CodeGen.Tests.MinimalDeps/Uno.CodeGen.Tests.MinimalDeps.csproj
+++ b/src/Uno.CodeGen.Tests.MinimalDeps/Uno.CodeGen.Tests.MinimalDeps.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net461;netstandard2.0;netstandard1.3</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<SourceGenerator Include="..\Uno.CodeGen\bin\$(Configuration)\net461\Uno.CodeGen.dll" />
+	</ItemGroup>
+
+	<Import Project="..\Uno.CodeGen\build\Uno.CodeGen.props" />
+
+	<!--
+    *******************************************************************
+    * This project is meant only to check if the compilation succeeds *
+    * with minimal set of dependencies.                               *
+    * Please do not add any other dependency to this project!         *
+    *******************************************************************
+    -->
+  
+	<ItemGroup>
+		<PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Injectable\Uno.Injectable.csproj" />
+		<ProjectReference Include="..\Uno.Equality\Uno.Equality.csproj" />
+		<ProjectReference Include="..\Uno.Immutables\Uno.Immutables.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.CodeGen.sln
+++ b/src/Uno.CodeGen.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.CodeGen.Tests.ExternalC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Injectable", "Uno.Injectable\Uno.Injectable.csproj", "{5D545289-1318-428E-8ED9-5D5BA9BFE244}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.CodeGen.Tests.MinimalDeps", "Uno.CodeGen.Tests.MinimalDeps\Uno.CodeGen.Tests.MinimalDeps.csproj", "{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{5D545289-1318-428E-8ED9-5D5BA9BFE244}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D545289-1318-428E-8ED9-5D5BA9BFE244}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D545289-1318-428E-8ED9-5D5BA9BFE244}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Uno.CodeGen/EqualityGenerator.cs
+++ b/src/Uno.CodeGen/EqualityGenerator.cs
@@ -128,7 +128,7 @@ namespace Uno
 			_equalityHashAttributeSymbol = GetMandatoryTypeSymbol("Uno.EqualityHashAttribute");
 			_equalityKeyAttributeSymbol = GetMandatoryTypeSymbol("Uno.EqualityKeyAttribute");
 			_equalityComparerOptionsAttributeSymbol = GetMandatoryTypeSymbol("Uno.Equality.EqualityComparerOptionsAttribute");
-			_dataAnnonationsKeyAttributeSymbol = GetMandatoryTypeSymbol("System.ComponentModel.DataAnnotations.KeyAttribute");
+			_dataAnnonationsKeyAttributeSymbol = context.Compilation.GetTypeByMetadataName("System.ComponentModel.DataAnnotations.KeyAttribute");
 			_isPureAttributePresent = context.Compilation.GetTypeByMetadataName("System.Diagnostics.Contracts.Pure") != null;
 
 			_generateKeyEqualityCode = _iKeyEquatableSymbol != null;

--- a/src/Uno.CodeGen/EqualityGenerator.cs
+++ b/src/Uno.CodeGen/EqualityGenerator.cs
@@ -121,8 +121,8 @@ namespace Uno
 			_arraySymbol = GetMandatoryTypeSymbol("System.Array");
 			_collectionSymbol = GetMandatoryTypeSymbol("System.Collections.ICollection");
 			_iEquatableSymbol = GetMandatoryTypeSymbol("System.IEquatable`1");
-			_iKeyEquatableSymbol = _context.Compilation.GetTypeByMetadataName("Uno.Equality.IKeyEquatable");
-			_iKeyEquatableGenericSymbol = _context.Compilation.GetTypeByMetadataName("Uno.Equality.IKeyEquatable`1");
+			_iKeyEquatableSymbol = context.Compilation.GetTypeByMetadataName("Uno.Equality.IKeyEquatable");
+			_iKeyEquatableGenericSymbol = context.Compilation.GetTypeByMetadataName("Uno.Equality.IKeyEquatable`1");
 			_generatedEqualityAttributeSymbol = GetMandatoryTypeSymbol("Uno.GeneratedEqualityAttribute");
 			_ignoreForEqualityAttributeSymbol = GetMandatoryTypeSymbol("Uno.EqualityIgnoreAttribute");
 			_equalityHashAttributeSymbol = GetMandatoryTypeSymbol("Uno.EqualityHashAttribute");


### PR DESCRIPTION
I'm very sorry, but my last PR #122 introduces a regression: when compiling a minimal project targeting NETFramework or NETStandard the new `GetMandatoryTypeSymbol` complains about missing `System.ComponentModel.DataAnnotations.KeyAttribute`.

This PR fixes the issue, but i'm not totally convinced about `GetMandatoryTypeSymbol`: i'm not totally sure if the symbols imported this way are actually mandatory!!! 
**Please double check it before merge this PR** (or probably is better to rollback all symbols imports to `context.Compilation.GetTypeByMetadataName`)

Sorry again...