### PR TITLE
add support for System.Text.Json serialization

### DIFF
--- a/doc/Immutable Generation.md
+++ b/doc/Immutable Generation.md
@@ -36,9 +36,10 @@
 1. Restrictions:
    * **No default constructor allowed**
      (will with [Newtownsoft's JSON.NET](https://www.newtonsoft.com/json),
+     or with [new .NET Core 3.0 API](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-apis/) [System.Text.Json](https://docs.microsoft.com/en-us/dotnet/api/system.text.json?view=netcore-3.1)
      when detected, it will generate custom JSON Converter. You can disable
      this globally by setting this attribute:
-     `[assembly: ImmutableGenerationOptions(GenerateNewtownsoftJsonNetConverters=false)]`)
+     `[assembly: ImmutableGenerationOptions(GenerateNewtownsoftJsonNetConverters=false, GenerateSystemTextJsonConverters=false)]`
    * **No property setters allowed** (even `private` ones):
      properties should be _read only_, even for the class itself.
    * **No fields allowed** (except static fields, or `readonly` fields of a recognized immutable type).
@@ -259,13 +260,14 @@ The generated code will produce the following effect:
 
 # FAQ
 
-## What if I need to use it with [Newtownsoft's JSON.NET](https://www.newtonsoft.com/json)?
+## What if I need to use it with [Newtownsoft's JSON.NET](https://www.newtonsoft.com/json) or with [System.Text.Json](https://docs.microsoft.com/en-us/dotnet/api/system.text.json?view=netcore-3.1)?
 You simply need to deserialize the builder instead of the class itself.
 The implicit casting will automatically convert it to the right type.
 
 Example:
 ``` csharp
-  MyEntity e = JsonConvert.DeserializeObject<MyEntity.Builder>(json);
+  MyEntity e1 = Newtonsoft.Json.JsonConvert.DeserializeObject<MyEntity.Builder>(json);
+  MyEntity e2 = System.Text.Json.JsonSerializer.Deserialize<MyEntity.Builder>(json);
 ```
 
 ## It's generating a lot of unused method. It's a waste.

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ Features:
 * Works with generics & derived classes (even if they are from external assembly)
 * Optional support (_on_ by default) for `[GeneratedEquality]`
 * Transparent support for _Newtonsoft's JSON.NET_ (activated when detected, can be turned off)
+* Transparent support for _System.Text.Json_ (activated when detected, can be turned off)
 * Debuggable: You can put a breakpoint directly in the generated code
 * Validation to avoid mutable code in your class
 * Highly configureable: Generated code provides a lot of useful tips (stripped in previous snippet)

--- a/src/Uno.CodeGen.Tests.JsonDisabled/JsonTestObj.cs
+++ b/src/Uno.CodeGen.Tests.JsonDisabled/JsonTestObj.cs
@@ -1,0 +1,41 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+[assembly:Uno.ImmutableGenerationOptions(GenerateNewtownsoftJsonNetConverters = false, GenerateSystemTextJsonConverters = false)]
+
+namespace Uno.CodeGen.Tests.JsonDisabled
+{
+	[GeneratedImmutable]
+	public partial class JsonTestObj
+	{
+		public Type T { get; }
+
+		public JsonTestObjChild Entity { get; } = JsonTestObjChild.Default;
+
+		public bool IsSomething { get; } = true;
+
+	}
+
+	[GeneratedImmutable]
+	public partial class JsonTestObjChild
+	{
+		public int MyField1 { get; } = 4;
+
+		public int MyField2 { get; } = 75;
+	}
+
+}

--- a/src/Uno.CodeGen.Tests.JsonDisabled/Uno.CodeGen.Tests.JsonDisabled.csproj
+++ b/src/Uno.CodeGen.Tests.JsonDisabled/Uno.CodeGen.Tests.JsonDisabled.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net461</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<SourceGenerator Include="..\Uno.CodeGen\bin\$(Configuration)\net461\Uno.CodeGen.dll" />
+	</ItemGroup>
+
+	<Import Project="..\Uno.CodeGen\build\Uno.CodeGen.props" />
+  
+	<ItemGroup>
+		<PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245" />
+        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+	    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    </ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Injectable\Uno.Injectable.csproj" />
+		<ProjectReference Include="..\Uno.Equality\Uno.Equality.csproj" />
+		<ProjectReference Include="..\Uno.Immutables\Uno.Immutables.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.CodeGen.Tests.MinimalDeps/JsonTestObj.cs
+++ b/src/Uno.CodeGen.Tests.MinimalDeps/JsonTestObj.cs
@@ -14,12 +14,27 @@
 // limitations under the License.
 //
 // ******************************************************************
+using System;
+
 namespace Uno.CodeGen.Tests.MinimalDeps
 {
 	[GeneratedImmutable]
-	public partial class Class1
+	public partial class JsonTestObj
 	{
-		[EqualityHash]
-		public string Id { get; }
+		public Type T { get; }
+
+		public JsonTestObjChild Entity { get; } = JsonTestObjChild.Default;
+
+		public bool IsSomething { get; } = true;
+
 	}
+
+	[GeneratedImmutable]
+	public partial class JsonTestObjChild
+	{
+		public int MyField1 { get; } = 4;
+
+		public int MyField2 { get; } = 75;
+	}
+
 }

--- a/src/Uno.CodeGen.Tests/Given_ImmutableEntity.NoJson.cs
+++ b/src/Uno.CodeGen.Tests/Given_ImmutableEntity.NoJson.cs
@@ -1,0 +1,201 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WithoutJsonRefs = Uno.CodeGen.Tests.MinimalDeps.JsonTestObj;
+using WithJsonDisabled = Uno.CodeGen.Tests.JsonDisabled.JsonTestObj;
+using STJ = System.Text.Json;
+using NJ = Newtonsoft.Json;
+
+namespace Uno.CodeGen.Tests
+{
+	public partial class Given_ImmutableEntity
+	{
+		#region Serialization
+		private void AssertJsonSerialized(string json)
+		{
+			json.Should().BeEquivalentTo("{\"T\":null,\"Entity\":{\"MyField1\":4,\"MyField2\":75},\"IsSomething\":true}");
+		}
+
+		[TestMethod]
+		public void Immutable_When_Serializing_WithoutJsonRefs_Using_SystemTextJson()
+		{
+			var json = STJ.JsonSerializer.Serialize(WithoutJsonRefs.Default);
+			AssertJsonSerialized(json);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Serializing_WithoutJsonRefs_Using_JsonNet()
+		{
+			var json = NJ.JsonConvert.SerializeObject(WithoutJsonRefs.Default);
+			AssertJsonSerialized(json);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Serializing_WithJsonDisabled_Using_SystemTextJson()
+		{
+			var json = STJ.JsonSerializer.Serialize(WithJsonDisabled.Default);
+			AssertJsonSerialized(json);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Serializing_WithJsonDisabled_Using_JsonNet()
+		{
+			var json = NJ.JsonConvert.SerializeObject(WithJsonDisabled.Default);
+			AssertJsonSerialized(json);
+		}
+		#endregion Serialization
+
+		#region DeserializeBuilderWithoutChild
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithoutJsonRefsBuilder_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null}";
+			var a = STJ.JsonSerializer.Deserialize<WithoutJsonRefs.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(4);
+			a.Entity­.MyField2.Should().Be(75);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithoutJsonRefsBuilder_Using_JsonNet()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null}";
+			var a = NJ.JsonConvert.DeserializeObject<WithoutJsonRefs.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(4);
+			a.Entity­.MyField2.Should().Be(75);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithJsonDisabledBuilder_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null}";
+			var a = STJ.JsonSerializer.Deserialize<WithJsonDisabled.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(4);
+			a.Entity­.MyField2.Should().Be(75);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithJsonDisabledBuilder_Using_JsonNet()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null}";
+			var a = NJ.JsonConvert.DeserializeObject<WithJsonDisabled.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(4);
+			a.Entity­.MyField2.Should().Be(75);
+		}
+		#endregion DeserializeBuilderWithoutChild
+
+		#region DeserializeBuilderWithChild
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithoutJsonRefsBuilderAndChild_Using_SystemTextJson()
+		{
+			//System.Text.Json fails with exception to deserialize because the child property Entity is immutable and there is no converter
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			json.Invoking(j => STJ.JsonSerializer.Deserialize<WithoutJsonRefs.Builder>(j))
+				.Should().Throw<System.MissingMemberException>();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithoutJsonRefsBuilderAndChild_Using_JsonNet()
+		{
+			//WARNING!!!!
+			//Newtonsoft.Json silently leave default because child property Entity is immutable and there is no converter
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			var a = NJ.JsonConvert.DeserializeObject<WithoutJsonRefs.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(4);
+			a.Entity­.MyField2.Should().Be(75);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithJsonDisabledBuilderAndChild_Using_SystemTextJson()
+		{
+			//System.Text.Json fails with exception to deserialize because the child property Entity is immutable and there is no converter
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			json.Invoking(j => STJ.JsonSerializer.Deserialize<WithJsonDisabled.Builder>(j))
+				.Should().Throw<System.MissingMemberException>();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithJsonDisabledBuilderAndChild_Using_JsonNet()
+		{
+			//WARNING!!!!
+			//Newtonsoft.Json silently leave default because child property Entity is immutable and there is no converter
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			var a = NJ.JsonConvert.DeserializeObject<WithJsonDisabled.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(4);
+			a.Entity­.MyField2.Should().Be(75);
+		}
+		#endregion DeserializeBuilderWithChild
+
+		#region DeserializeImmutable
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithoutJsonRefs_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			json.Invoking(j => STJ.JsonSerializer.Deserialize<WithoutJsonRefs>(j))
+				.Should().Throw<System.MissingMemberException>();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithoutJsonRefs_Using_JsonNet()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			json.Invoking(j => NJ.JsonConvert.DeserializeObject<WithoutJsonRefs>(j))
+				.Should().Throw<System.ArgumentNullException>();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithJsonDisabled_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			json.Invoking(j => STJ.JsonSerializer.Deserialize<WithJsonDisabled>(j))
+				.Should().Throw<System.MissingMemberException>();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_WithJsonDisabled_Using_JsonNet()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			json.Invoking(j => NJ.JsonConvert.DeserializeObject<WithJsonDisabled>(j))
+				.Should().Throw<System.ArgumentNullException>();
+		}
+		#endregion DeserializeImmutable
+	}
+}

--- a/src/Uno.CodeGen.Tests/Given_ImmutableEntity.SystemTextJson.cs
+++ b/src/Uno.CodeGen.Tests/Given_ImmutableEntity.SystemTextJson.cs
@@ -1,0 +1,89 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace Uno.CodeGen.Tests
+{
+	public partial class Given_ImmutableEntity
+	{
+		[TestMethod]
+		public void Immutable_When_Serializing_A_Using_SystemTextJson()
+		{
+			var json = JsonSerializer.Serialize(A.Default.WithEntity(x => null).ToImmutable());
+
+			json.Should().BeEquivalentTo("{\"T\":null,\"Entity\":null,\"IsSomething\":true,\"Metadata\":null}");
+		}
+
+		[TestMethod]
+		public void Immutable_When_Serializing_ABuilder_Using_SystemTextJson()
+		{
+			var json = JsonSerializer.Serialize(A.Default.WithEntity(x => null));
+
+			json.Should().BeEquivalentTo("{\"T\":null,\"Entity\":null,\"IsSomething\":true,\"Metadata\":null}");
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_ABuilder_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			var a = JsonSerializer.Deserialize<A.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(1);
+			a.Entity­.MyField2.Should().Be(2);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_A_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":{\"MyField1\":1, \"MyField2\":2}}";
+			var a = JsonSerializer.Deserialize<A>(json);
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().NotBeNull();
+			a.Entity­.MyField1.Should().Be(1);
+			a.Entity­.MyField2.Should().Be(2);
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_ABuilder_WithNull_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":null}";
+			var a = JsonSerializer.Deserialize<A.Builder>(json).ToImmutable();
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void Immutable_When_Deserializing_A_WithNull_Using_SystemTextJson()
+		{
+			const string json = "{\"IsSomething\":false, \"T\":null, \"Entity\":null}";
+			var a = JsonSerializer.Deserialize<A>(json);
+			a.Should().NotBeNull();
+			a.IsSomething.Should().BeFalse();
+			a.T.Should().BeNull();
+			a.Entity.Should().BeNull();
+		}
+	}
+}

--- a/src/Uno.CodeGen.Tests/Uno.CodeGen.Tests.csproj
+++ b/src/Uno.CodeGen.Tests/Uno.CodeGen.Tests.csproj
@@ -18,6 +18,7 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+		<PackageReference Include="System.Text.Json" Version="4.7.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
 		<PackageReference Include="Uno.Core" Version="1.27.0-dev.65" />

--- a/src/Uno.CodeGen.Tests/Uno.CodeGen.Tests.csproj
+++ b/src/Uno.CodeGen.Tests/Uno.CodeGen.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net461</TargetFramework>
@@ -38,6 +38,8 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.ClassLifecycle\Uno.ClassLifecycle.csproj" />
 		<ProjectReference Include="..\Uno.CodeGen.Tests.ExternalClasses\Uno.CodeGen.Tests.ExternalClasses.csproj" />
+		<ProjectReference Include="..\Uno.CodeGen.Tests.MinimalDeps\Uno.CodeGen.Tests.MinimalDeps.csproj" />
+		<ProjectReference Include="..\Uno.CodeGen.Tests.JsonDisabled\Uno.CodeGen.Tests.JsonDisabled.csproj" />
 		<ProjectReference Include="..\Uno.Injectable\Uno.Injectable.csproj" />
 		<ProjectReference Include="..\Uno.Equality\Uno.Equality.csproj" />
 		<ProjectReference Include="..\Uno.Immutables\Uno.Immutables.csproj" />

--- a/src/Uno.CodeGen.sln
+++ b/src/Uno.CodeGen.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Injectable", "Uno.Injec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.CodeGen.Tests.MinimalDeps", "Uno.CodeGen.Tests.MinimalDeps\Uno.CodeGen.Tests.MinimalDeps.csproj", "{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.CodeGen.Tests.JsonDisabled", "Uno.CodeGen.Tests.JsonDisabled\Uno.CodeGen.Tests.JsonDisabled.csproj", "{8A1F7BE0-46F6-455B-8720-5B0698843733}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36B61385-CE6D-4493-8AFF-F77F1E4F7CFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A1F7BE0-46F6-455B-8720-5B0698843733}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A1F7BE0-46F6-455B-8720-5B0698843733}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A1F7BE0-46F6-455B-8720-5B0698843733}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A1F7BE0-46F6-455B-8720-5B0698843733}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Uno.CodeGen/ImmutableGenerator.cs
+++ b/src/Uno.CodeGen/ImmutableGenerator.cs
@@ -52,9 +52,10 @@ namespace Uno
 		private INamedTypeSymbol _immutableGenerationOptionsAttributeSymbol;
 		private INamedTypeSymbol _immutableTreatAsImmutableAttributeSymbol;
 
-		private (bool generateOptionCode, bool treatArrayAsImmutable, bool generateEqualityByDefault, bool generateJsonNet) _generationOptions;
+		private (bool generateOptionCode, bool treatArrayAsImmutable, bool generateEqualityByDefault, bool generateJsonNet, bool generateSystemTextJson) _generationOptions;
 		private bool _generateOptionCode = true;
 		private bool _generateJsonNet = true;
+		private bool _generateSystemTextJson = true;
 
 		private string _currentType;
 
@@ -100,6 +101,7 @@ namespace Uno
 			_generateOptionCode = _generationOptions.generateOptionCode && context.Compilation.GetTypeByMetadataName("Uno.Option") != null;
 
 			_generateJsonNet = _generationOptions.generateOptionCode && context.Compilation.GetTypeByMetadataName("Newtonsoft.Json.JsonConvert") != null;
+			_generateSystemTextJson = _generationOptions.generateOptionCode && context.Compilation.GetTypeByMetadataName("System.Text.Json.Serialization.JsonConverter") != null;
 
 			foreach (var (type, moduleAttribute) in generationData)
 			{
@@ -118,12 +120,13 @@ namespace Uno
 				.Select(a => new Regex(a.ConstructorArguments[0].Value.ToString()));
 		}
 
-		private (bool generateOptionCode, bool treatArrayAsImmutable, bool generateEqualityByDefault, bool generateJsonNet) ExtractGenerationOptions(IAssemblySymbol assembly)
+		private (bool generateOptionCode, bool treatArrayAsImmutable, bool generateEqualityByDefault, bool generateJsonNet, bool generateSystemTextJson) ExtractGenerationOptions(IAssemblySymbol assembly)
 		{
 			var generateOptionCode = true;
 			var treatArrayAsImmutable = false;
 			var generateEqualityByDefault = true;
 			var generateJsonNet = true;
+			var generateSystemTextJson = true;
 
 			var attribute = assembly
 				.GetAttributes()
@@ -147,11 +150,14 @@ namespace Uno
 						case nameof(ImmutableGenerationOptionsAttribute.GenerateNewtownsoftJsonNetConverters):
 							generateJsonNet = (bool)argument.Value.Value;
 							break;
+						case nameof(ImmutableGenerationOptionsAttribute.GenerateSystemTextJsonConverters):
+							generateSystemTextJson = (bool)argument.Value.Value;
+							break;
 					}
 				}
 			}
 
-			return (generateOptionCode, treatArrayAsImmutable, generateEqualityByDefault, generateJsonNet);
+			return (generateOptionCode, treatArrayAsImmutable, generateEqualityByDefault, generateJsonNet, generateSystemTextJson);
 		}
 
 		private bool GetShouldGenerateEquality(AttributeData attribute)
@@ -215,6 +221,7 @@ namespace Uno
 
 			var generateOption = _generateOptionCode && !typeSymbol.IsAbstract;
 			var generateJsonNet = _generateJsonNet && !typeSymbol.IsAbstract;
+			var generateSystemTextJson = _generateSystemTextJson && !typeSymbol.IsAbstract;
 
 			var classCopyIgnoreRegexes = ExtractCopyIgnoreAttributes(typeSymbol).ToArray();
 
@@ -296,6 +303,11 @@ namespace Uno
 				if (generateJsonNet)
 				{
 					builder.AppendLineInvariant($"[global::Newtonsoft.Json.JsonConverter(typeof({symbolName}BuilderJsonConverterTo{symbolNameDefinition}))]");
+				}
+
+				if (generateSystemTextJson)
+				{
+					builder.AppendLineInvariant($"[global::System.Text.Json.Serialization.JsonConverter(typeof({symbolName}BuilderSystemTextJsonConverterTo{symbolNameDefinition}))]");
 				}
 
 				builder.AppendLineInvariant($"[global::Uno.ImmutableBuilder(typeof({symbolNameDefinition}.Builder))] // Other generators can use this to find the builder.");
@@ -800,6 +812,26 @@ $@"public sealed class {symbolName}BuilderJsonConverterTo{symbolName}{genericArg
 	public override bool CanConvert(Type objectType)
 	{{
 		return objectType == typeof({symbolNameWithGenerics}) || objectType == typeof({symbolNameWithGenerics}.Builder);
+	}}
+}}");
+
+					builder.AppendLine();
+				}
+
+				if (generateSystemTextJson)
+				{
+					builder.AppendLine(
+$@"{typeSymbol.GetAccessibilityAsCSharpCodeString()} sealed class {symbolName}BuilderSystemTextJsonConverterTo{symbolName}{genericArguments} : global::System.Text.Json.Serialization.JsonConverter<{symbolNameWithGenerics}>{genericConstraints}
+{{
+	public override void Write(global::System.Text.Json.Utf8JsonWriter writer, {symbolName}{genericArguments} value, global::System.Text.Json.JsonSerializerOptions options)
+	{{
+		global::System.Text.Json.JsonSerializer.Serialize<{symbolNameWithGenerics}.Builder>(writer, value, options);
+	}}
+
+	public override {symbolName}{genericArguments} Read(ref global::System.Text.Json.Utf8JsonReader reader, Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
+	{{
+		var v = global::System.Text.Json.JsonSerializer.Deserialize<{symbolNameWithGenerics}.Builder>(ref reader, options);
+		return v?.ToImmutable();
 	}}
 }}");
 

--- a/src/Uno.CodeGen/ImmutableGenerator.cs
+++ b/src/Uno.CodeGen/ImmutableGenerator.cs
@@ -99,9 +99,8 @@ namespace Uno
 			_generationOptions = ExtractGenerationOptions(context.Compilation.Assembly);
 
 			_generateOptionCode = _generationOptions.generateOptionCode && context.Compilation.GetTypeByMetadataName("Uno.Option") != null;
-
-			_generateJsonNet = _generationOptions.generateOptionCode && context.Compilation.GetTypeByMetadataName("Newtonsoft.Json.JsonConvert") != null;
-			_generateSystemTextJson = _generationOptions.generateOptionCode && context.Compilation.GetTypeByMetadataName("System.Text.Json.Serialization.JsonConverter") != null;
+			_generateJsonNet = _generationOptions.generateJsonNet && context.Compilation.GetTypeByMetadataName("Newtonsoft.Json.JsonConvert") != null;
+			_generateSystemTextJson = _generationOptions.generateSystemTextJson && context.Compilation.GetTypeByMetadataName("System.Text.Json.Serialization.JsonConverter") != null;
 
 			foreach (var (type, moduleAttribute) in generationData)
 			{

--- a/src/Uno.Immutables/ImmutableGenerationOptionsAttribute.cs
+++ b/src/Uno.Immutables/ImmutableGenerationOptionsAttribute.cs
@@ -57,5 +57,13 @@ namespace Uno
 		/// Default is true. No effect if package `Newtownsoft.Json` is not referenced.
 		/// </remarks>
 		public bool GenerateNewtownsoftJsonNetConverters { get; set; } = true;
+
+		/// <summary>
+		/// If you want to generate System.Text.Json converters by default.
+		/// </summary>
+		/// <remarks>
+		/// Default is true. No effect if package `System.Text.Json` is not referenced.
+		/// </remarks>
+		public bool GenerateSystemTextJsonConverters { get; set; } = true;
 	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
.NET Core 3.0 has a new API for json serialization (see https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-apis/) but it's not supported by Uno.Immutables...

## What is the new behavior?
`System.Text.Json` API is supported exactly like the well known `Newtonsoft.Json`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.CodeGen/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.CodeGen/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

