### PR TITLE
fix: Remove depedency on internal IsAutoProperty, TupleTypeSymbol

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,33 +1,54 @@
 assembly-versioning-scheme: MajorMinorPatch
-mode: ContinuousDeployment
-next-version: 1.33.0
-continuous-delivery-fallback-tag: ""
+mode: Mainline
+next-version: 1.34.0
+
 branches:
   master:
+    mode: ContinuousDeployment
     regex: master
     tag: dev
-    increment: none
+    increment: Minor
+    is-source-branch-for: ['beta', 'stable']
+
+  pull-request:
+    regex: ^(pull|pull\-requests|pr)[/-]
+    mode: ContinuousDeployment
+    tag: 'PullRequest'
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    increment: Inherit
+
   beta:
-    regex: release/beta/
-    tag: 'beta'
+    mode: ContinuousDeployment
+    regex: ^release/beta/.*
+    tag: beta
     increment: none
     source-branches: ['master']
+
   stable:
-    regex: release/stable/
+    regex: ^release/stable/.*
     tag: ''
-    increment: none
-    source-branches: ['master']
+    increment: Patch
+    source-branches: ['master','beta']
+    is-mainline: true
+
   dev:
-    regex: dev/.*?/(.*?)
+    mode: ContinuousDeployment
+    regex: ^dev/.*?/(.*?)
     tag: dev.{BranchName}
-    source-branches: ['master']
+    source-branches: ['master', 'release', 'projects', 'feature']
+    increment: none
+
   projects:
     tag: proj-{BranchName}
-    regex: projects/(.*?)
+    regex: ^projects/(.*?)
     source-branches: ['master']
+    increment: none
+
   feature:
     tag: feature.{BranchName}
-    regex: feature/(.*?)
+    regex: ^feature/(.*?)
     source-branches: ['master']
+    increment: none
+
 ignore:
   sha: []

--- a/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
+++ b/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
@@ -25,7 +25,7 @@ This package is part of the Uno.CodeGen to generate classes lifecycle methods in
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" PrivateAssets="all" />
 		<PackageReference Include="Uno.RoslynHelpers" Version="1.2.0-dev.10" PrivateAssets="all" />
-		<PackageReference Include="Uno.SourceGeneration" Version="1.30.0-dev.245" PrivateAssets="all" />
+		<PackageReference Include="Uno.SourceGeneration" Version="1.30.0-dev.245" PrivateAssets="all" ExcludeAssets="runtime" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Uno.CodeGen/Helpers/TypeSymbolExtensions.cs
+++ b/src/Uno.CodeGen/Helpers/TypeSymbolExtensions.cs
@@ -338,8 +338,6 @@ namespace Uno.Helpers
 			return keyType != null;
 		}
 
-		private static MethodInfo _isAutoPropertyGetter;
-
 		public static bool IsAutoProperty(this IPropertySymbol symbol)
 		{
 			if (symbol.IsWithEvents || symbol.IsIndexer || !symbol.IsReadOnly)

--- a/src/Uno.CodeGen/Uno.CodeGen.csproj
+++ b/src/Uno.CodeGen/Uno.CodeGen.csproj
@@ -21,17 +21,17 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
 	<PackageReference Include="System.ValueTuple" Version="4.4.0" PrivateAssets="all" />
 	<PackageReference Include="Uno.RoslynHelpers" Version="1.2.0-dev.10" PrivateAssets="all" />
-	<PackageReference Include="Uno.SourceGeneration" Version="1.30.0-dev.245" PrivateAssets="all" />
+	<PackageReference Include="Uno.SourceGeneration" Version="1.30.0-dev.245" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.CodeAnalysis" Version="2.3.0" PrivateAssets="all" />
+	<PackageReference Include="Microsoft.CodeAnalysis" Version="2.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
 	<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
 	<PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245" PrivateAssets="none">
-		<NoWarn>NU1701</NoWarn>
+	  <NoWarn>NU1701</NoWarn>
 	</PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes execution failures running with Roslyn 3.6